### PR TITLE
Added a clean-volume initContainer

### DIFF
--- a/k8s/production.yml
+++ b/k8s/production.yml
@@ -46,6 +46,15 @@ spec:
             cpu: 50m
             memory: 512Mi
       initContainers:
+      - name: clean-volume
+        image: busybox
+        command:
+        - rm
+        - "-rf"
+        - "/var/planet/config"
+        volumeMounts:
+        - name: planet-config
+          mountPath: "/var/planet/config"
       - name: git-clone
         image: alpine/git
         command:


### PR DESCRIPTION
This is required in case the git clone fails after having written to "planet-config". In such case, the git-clone container will be restarted but will continuously fail as git clone in an existing directory is only allowed iif the directory is empty.

Signed-off-by: Mikaël Barbero <mikael.barbero@eclipse-foundation.org>