### PR TITLE
fix: Update mastertheboss feed URL to fix missing upstream link

### DIFF
--- a/planet/planet.ini
+++ b/planet/planet.ini
@@ -202,7 +202,7 @@ name = Markus Karg
 picture = markus-karg.png
 
 # Francesco Marchioni
-[https://www.mastertheboss.com/feed/?cat=108,110]
+[https://www.mastertheboss.com/category/java-ee/jakarta-ee/feed/]
 name = Francesco Marchioni
 picture = francesco-marchioni.png
 


### PR DESCRIPTION
Previous feed URL had no `link` associated, which venus uses as an ID in the limiting of feed items. This lead to no limiting being present on the named feed. New feed has a link, which resolves the issue.

Resolves #110